### PR TITLE
Add attachment support to queue

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -1,4 +1,5 @@
-import os, re, time, random, discord, openai,tempfile
+import os, re, time, random, discord, openai, tempfile, uuid
+from dataclasses import dataclass
 
 # ───────────────── TOKEN / KEY ─────────────────
 with open("token.txt", "r", encoding="utf-8") as f:
@@ -39,27 +40,81 @@ YTDL_OPTS = {
     "quiet": True,
     "format": "bestaudio[ext=m4a]/bestaudio/best",
     "default_search": "ytsearch",
-    "noplaylist": True,
 }
 
-def yt_extract(url_or_term: str) -> tuple[str, str]:
-    """(title, direct_audio_url) を返す"""
+@dataclass
+class Track:
+    title: str
+    url: str
+    duration: int | None = None
+
+AUDIO_EXTS = {".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac"}
+TEMP_DIR = tempfile.gettempdir()
+
+def yt_extract(url_or_term: str) -> list[Track]:
+    """URL か検索語から Track 一覧を返す (単曲の場合は長さ1)"""
     with YoutubeDL(YTDL_OPTS) as ydl:
         info = ydl.extract_info(url_or_term, download=False)
-        # ytsearch の場合は 'entries' にリストされる
         if "entries" in info:
+            if info.get("_type") == "playlist":
+                results = []
+                for ent in info.get("entries", []):
+                    if ent:
+                        results.append(Track(ent.get("title", "?"), ent.get("url", ""), ent.get("duration")))
+                return results
             info = info["entries"][0]
-        return info["title"], info["url"]
+        return [Track(info.get("title", "?"), info.get("url", ""), info.get("duration"))]
     
 import asyncio, collections
 
+def fmt_time(sec: int) -> str:
+    m, s = divmod(int(sec), 60)
+    h, m = divmod(m, 60)
+    if h:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m:02d}:{s:02d}"
+
+def make_bar(pos: int, total: int, width: int = 15) -> str:
+    if total <= 0:
+        return "".ljust(width, "─")
+    index = round(pos / total * (width - 1))
+    return "━" * index + "⚪" + "─" * (width - index - 1)
+
+def num_emoji(n: int) -> str:
+    emojis = ["0️⃣","1️⃣","2️⃣","3️⃣","4️⃣","5️⃣","6️⃣","7️⃣","8️⃣","9️⃣","🔟"]
+    return emojis[n] if 0 <= n < len(emojis) else str(n)
+
+async def attachment_to_track(att: discord.Attachment) -> Track:
+    """添付ファイルを保存して Track に変換"""
+    ext = os.path.splitext(att.filename)[1].lower()
+    name = f"{uuid.uuid4().hex}{ext}"
+    path = os.path.join(TEMP_DIR, name)
+    await att.save(path)
+    return Track(att.filename, path, None)
+
+def cleanup_track(track: Track):
+    """一時ファイルであれば削除"""
+    if track.url.startswith(TEMP_DIR):
+        try:
+            os.remove(track.url)
+        except FileNotFoundError:
+            pass
+
+def cleanup_state(state: "MusicState"):
+    if state.current:
+        cleanup_track(state.current)
+    while state.queue:
+        cleanup_track(state.queue.popleft())
+
 class MusicState:
     def __init__(self):
-        self.queue   = collections.deque()
-        self.loop    = False
-        self.current = None
+        self.queue   = collections.deque()   # 再生待ち Track 一覧
+        self.loop    = 0  # 0:OFF,1:SONG,2:QUEUE
+        self.auto_leave = True             # 全員退出時に自動で切断するか
+        self.current: Track | None = None
         self.play_next = asyncio.Event()
-        self.queue_msg: discord.Message | None = None   # ← 追加
+        self.queue_msg: discord.Message | None = None
+        self.start_time: float | None = None
 
     async def player_loop(self, voice: discord.VoiceClient, channel: discord.TextChannel):
         """
@@ -76,11 +131,13 @@ class MusicState:
                 if not self.queue:
                     await voice.disconnect()
                     self.queue_msg = None
+                    cleanup_state(self)
+                    guild_states.pop(voice.guild.id, None)
                     return
 
             # 再生準備
             self.current = self.queue[0]
-            title, url   = self.current
+            title, url = self.current.title, self.current.url
 
             ffmpeg_audio = discord.FFmpegPCMAudio(
                 source=url,
@@ -89,17 +146,30 @@ class MusicState:
                 options='-vn -loglevel warning -af "volume=0.9"'
             )
             voice.play(ffmpeg_audio, after=lambda _: self.play_next.set())
+            self.start_time = time.time()
 
             # チャット通知 & Embed 更新
             await channel.send(f"▶️ **Now playing**: {title}")
             await refresh_queue(self)
 
+            progress_task = asyncio.create_task(progress_updater(self))
+
             # 次曲まで待機
             await self.play_next.wait()
+            progress_task.cancel()
+            self.start_time = None
 
+            finished = self.current
             # ループOFFなら再生し終えた曲をキューから外す
-            if not self.loop and self.queue:
-                self.queue.popleft()
+            if self.loop == 0 and self.queue:
+                popped = self.queue.popleft()
+                cleanup_track(popped)
+            elif self.loop == 2 and self.queue:
+                self.queue.rotate(-1)
+
+            # 使い終えた一時ファイルを除去
+            if finished and finished not in self.queue:
+                cleanup_track(finished)
 
 # クラス外でOK
 async def refresh_queue(state: "MusicState"):
@@ -109,6 +179,15 @@ async def refresh_queue(state: "MusicState"):
             await state.queue_msg.edit(embed=make_embed(state))
         except discord.HTTPException:
             pass
+
+async def progress_updater(state: "MusicState"):
+    """再生中は1秒ごとにシークバーを更新"""
+    try:
+        while True:
+            await asyncio.sleep(1)
+            await refresh_queue(state)
+    except asyncio.CancelledError:
+        pass
 
 # ──────────── 🖼 名言化 APIヘルパ ────────────
 import json, aiohttp, pathlib
@@ -216,8 +295,16 @@ def make_embed(state: "MusicState") -> discord.Embed:
 
     # Now Playing
     if state.current:
-        title, _ = state.current
-        emb.add_field(name="Now Playing", value=title, inline=False)
+        emb.add_field(name="▶️ Now Playing:", value=state.current.title, inline=False)
+        if state.start_time is not None and state.current.duration:
+            pos = int(time.time() - state.start_time)
+            pos = max(0, min(pos, state.current.duration))
+            bar = make_bar(pos, state.current.duration)
+            emb.add_field(
+                name=f"[{bar}] {fmt_time(pos)} / {fmt_time(state.current.duration)}",
+                value="\u200b",
+                inline=False
+            )
     else:
         emb.add_field(name="Now Playing", value="Nothing", inline=False)
 
@@ -228,10 +315,10 @@ def make_embed(state: "MusicState") -> discord.Embed:
 
     if queue_list:
         lines, chars = [], 0
-        for i, (t, _) in enumerate(queue_list):
-            line = f"{i+1}. {t}"
-            if chars + len(line) + 1 > 800:        # 800 文字で打ち止め
-                lines.append(f"…and **{len(queue_list)-i}** more")
+        for i, tr in enumerate(queue_list, 1):
+            line = f"{num_emoji(i)} {tr.title}"
+            if chars + len(line) + 1 > 800:
+                lines.append(f"…and **{len(queue_list)-i+1}** more")
                 break
             lines.append(line)
             chars += len(line) + 1
@@ -240,14 +327,23 @@ def make_embed(state: "MusicState") -> discord.Embed:
         body = "Empty"
 
     emb.add_field(name="Up Next", value=body, inline=False)
-    emb.set_footer(text=f"Loop: {'ON' if state.loop else 'OFF'}")
+    loop_map = {0: "OFF", 1: "Song", 2: "Queue"}
+    footer = f"Loop: {loop_map.get(state.loop, 'OFF')} | Auto Leave: {'ON' if state.auto_leave else 'OFF'}"
+    emb.set_footer(text=footer)
     return emb
 
 class ControlView(discord.ui.View):
-    """Skip / Shuffle / Pause / Resume / Loop をまとめた操作ボタン"""
+    """再生操作やループ・自動退出の切替ボタンをまとめた View"""
     def __init__(self, state: "MusicState", vc: discord.VoiceClient, owner_id: int):
         super().__init__(timeout=180)
         self.state, self.vc, self.owner_id = state, vc, owner_id
+        self._update_labels()
+
+    def _update_labels(self):
+        """各ボタンの表示を現在の状態に合わせて更新"""
+        labels = {0: "OFF", 1: "Song", 2: "Queue"}
+        self.loop_toggle.label = f"🔁 Loop: {labels[self.state.loop]}"
+        self.leave_toggle.label = f"👋 Auto Leave: {'ON' if self.state.auto_leave else 'OFF'}"
 
     async def interaction_check(self, itx: discord.Interaction) -> bool:
         if itx.user.id != self.owner_id:
@@ -276,9 +372,17 @@ class ControlView(discord.ui.View):
             self.vc.resume()
         await itx.response.defer()
 
-    @discord.ui.button(label="🔂 Loop ON/OFF", style=discord.ButtonStyle.success)
-    async def _loop_toggle(self, itx: discord.Interaction, _: discord.ui.Button):
-        self.state.loop = not self.state.loop
+    @discord.ui.button(label="🔁 Loop: OFF", style=discord.ButtonStyle.success)
+    async def loop_toggle(self, itx: discord.Interaction, btn: discord.ui.Button):
+        self.state.loop = (self.state.loop + 1) % 3
+        self._update_labels()
+        await refresh_queue(self.state)
+        await itx.response.defer()
+
+    @discord.ui.button(label="👋 Auto Leave: ON", style=discord.ButtonStyle.success)
+    async def leave_toggle(self, itx: discord.Interaction, btn: discord.ui.Button):
+        self.state.auto_leave = not self.state.auto_leave
+        self._update_labels()
         await refresh_queue(self.state)
         await itx.response.defer()
 
@@ -463,7 +567,7 @@ async def cmd_gpt(msg: discord.Message, prompt: str):
 async def cmd_play(msg: discord.Message, query: str):
     """曲をキューに追加して再生を開始"""
     if not query:
-        await msg.reply("`y!play <URL または 検索語>` の形式で使ってね！")
+        await msg.reply("`y!play <URL または 検索語>` + optional attachments で使ってね！")
         return
 
     voice = await ensure_voice(msg)
@@ -474,14 +578,31 @@ async def cmd_play(msg: discord.Message, query: str):
 
     # YouTube-DL/yt-dlp 等で URL 抽出
     try:
-        title, url = yt_extract(query)
+        tracks = yt_extract(query)
     except Exception as e:
         await msg.reply(f"🔍 取得失敗: {e}")
         return
-    
-    state.queue.append((title, url))
-    await refresh_queue(state)          # ← 追加
-    await msg.channel.send(f"⏱️ **Queued**: {title}")
+
+    # 添付ファイルもキューへ追加
+    ignored = []
+    for att in msg.attachments:
+        ext = os.path.splitext(att.filename)[1].lower()
+        if ext in AUDIO_EXTS:
+            tr = await attachment_to_track(att)
+            tracks.append(tr)
+        else:
+            ignored.append(att.filename)
+
+    state.queue.extend(tracks)
+    await refresh_queue(state)
+
+    if len(tracks) == 1:
+        await msg.channel.send(f"⏱️ **Queued**: {tracks[0].title}")
+    else:
+        await msg.channel.send(f"⏱️ Added {len(tracks)} tracks to queue")
+
+    if ignored:
+        await msg.channel.send("Ignored files: " + ", ".join(ignored))
 
     # 再生していなければループを起動
     if not voice.is_playing() and not state.play_next.is_set():
@@ -492,33 +613,38 @@ async def cmd_stop(msg: discord.Message, _):
     """Bot を VC から切断し、キュー初期化"""
     if vc := msg.guild.voice_client:
         await vc.disconnect()
-    guild_states.pop(msg.guild.id, None)
+    state = guild_states.pop(msg.guild.id, None)
+    if state:
+        cleanup_state(state)
     await msg.add_reaction("⏹️")
 
 
 # ──────────── 🎵  自動切断ハンドラ ────────────
 @client.event
 async def on_voice_state_update(member, before, after):
-    """誰かが VC から抜けた時 ― Bot だけ残ったら自動切断"""
-    if member.guild.id not in guild_states:
+    """誰かが VC から抜けた時、条件に応じて Bot を切断"""
+    state = guild_states.get(member.guild.id)
+    if not state:
         return
 
     voice: discord.VoiceClient | None = member.guild.voice_client
     if not voice or not voice.is_connected():
         return
 
-    # VC 内のヒト(≠bot) が 0 人になった？
-    if len([m for m in voice.channel.members if not m.bot]) == 0:
+    # VC 内のヒト(≠bot) が 0 人になった & auto_leave が有効？
+    if len([m for m in voice.channel.members if not m.bot]) == 0 and state.auto_leave:
         try:
             await voice.disconnect()
         finally:
-            guild_states.pop(member.guild.id, None)
+            st = guild_states.pop(member.guild.id, None)
+            if st:
+                cleanup_state(st)
 
 async def cmd_help(msg: discord.Message):
     await msg.channel.send(
         "**🎵 音楽機能**\n"
-        "`y!play <URL/キーワード>` - 曲をキューに追加して再生\n"
-        "`y!queue` - キュー表示＆ボタン操作（Skip / Shuffle / Pause / Resume / Loop）\n"
+        "`y!play <URL/キーワード/プレイリスト>` - 曲やプレイリスト、添付音声を追加\n"
+        "`y!queue` - キュー表示＆ボタン操作（Skip / Shuffle / Pause / Resume / Loop / Leave）\n"
         "\n"
         "**💬 翻訳機能**\n"
         "国旗リアクションを付けると、そのメッセージを自動翻訳\n"
@@ -894,11 +1020,11 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
                     {
                         "role": "system",
                         "content": (
-                            f"Translate the following text into {lang}. "
-                            f"The flag emoji is {emoji}. Return only the translation."
+                            f"Translate the user's message into {lang}. "
+                            f"The flag emoji is {emoji}. Respond only with the translated text without the emoji."
                         )
                     },
-                    {"role": "user", "content": f"{emoji} {original}"}
+                    {"role": "user", "content": original}
                 ],
                 max_tokens=1000,
                 temperature=0.3,
@@ -976,3 +1102,4 @@ async def on_message(msg: discord.Message):
 
 # ───────────────── 起動 ─────────────────
 client.run(TOKEN)
+


### PR DESCRIPTION
## Summary
- allow `y!play` to queue attached audio files after the URL or search results
- store attached files in the system temp directory and clean them up when done
- show ignored files if attachments aren't audio
- remove temp files when stopping or leaving voice channels
- show playback progress, loop status, and auto-leave status in queue
- add button to toggle auto-leave
- improve translation prompt so flag emoji is only in the system message

## Testing
- `python3 -m py_compile DiscordYONE.py`


------
https://chatgpt.com/codex/tasks/task_e_6860f03fefa4832cb7ac75f7932d9843