### PR TITLE
Improve command help and update OpenAI usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+discord.py
+openai>=1.0
+yt-dlp


### PR DESCRIPTION
## Summary
- load API keys from environment variables and fall back to files
- use `openai.OpenAI` client with `responses.create`
- update GPT and translation functions for new API
- expand `help` command text for both slash and prefix commands
- add `requirements.txt`

## Testing
- `python -m py_compile DiscordYONE.py`


------
https://chatgpt.com/codex/tasks/task_e_68613dc8eb70832cb8b4d80c1bd67a92