### PR TITLE
Add seek command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ YoneRai Discord Bot は、音楽再生、翻訳、AI 質問などの機能を備
   - Skip / Shuffle / Loop / Pause / Resume / Leave などをボタンで操作。
 - **曲削除**: `y!remove <番号>` / `/remove <番号>`
 - **一括削除**: `y!keep <番号>` / `/keep <番号>` で指定番号以外の曲を削除。
+- **シーク**: `y!seek <時間>` / `/seek <時間>` で指定位置から再生。
 - **退出**: `y!stop` / `/stop`
 
 ### 💬 翻訳


### PR DESCRIPTION
## Summary
- implement `parse_seek_time` and `fmt_time_jp`
- add seek support in player loop
- expose new `cmd_seek` for text and slash commands
- document the new command

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile DiscordYONE.py`


------
https://chatgpt.com/codex/tasks/task_e_686244a0c18c832c9852be5e9fa66b7c