### PR TITLE
Implement user and server info commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ YoneRai Discord Bot は、音楽再生、翻訳、AI 質問などの機能を備
 - **AI 質問**: `y? <質問>` / `/gpt <質問>` — GPT‑4.1 が Web 検索や Python 実行を用いて回答。
 
 ### 🧑 ユーザー情報
-- `y!user <ID>` / `/user <ID>` — 指定ユーザーのプロフィール表示。
+- `y!user <@メンション|ID>` / `/user [ユーザー]` — 指定ユーザーの詳細情報をEmbedで表示します。
+- `y!server` / `/server` — このサーバーの詳細情報をEmbedで表示します。
 
 ### 🕹️ その他
 - `y!ping` / `/ping` — 応答速度表示。


### PR DESCRIPTION
## Summary
- add detailed user information retrieval with `/user` and `y!user`
- add new `/server` and `y!server` commands
- update help messages and README accordingly

## Testing
- `python -m py_compile DiscordYONE.py`

------
https://chatgpt.com/codex/tasks/task_e_6862506065cc832c924a519c20d0866e