### PR TITLE
Fix missing bot startup

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -2465,3 +2465,7 @@ async def on_message(msg: discord.Message):
     elif cmd == "purge":await cmd_purge(msg, arg)
     elif cmd == "yomiage": await cmd_yomiage(msg)
     elif cmd == "mojiokosi": await cmd_mojiokosi(msg)
+
+# ───────────────── 起動 ─────────────────
+if __name__ == "__main__":
+    client.run(TOKEN)


### PR DESCRIPTION
## Summary
- add the missing `client.run` logic to start the Discord bot

## Testing
- `python -m py_compile DiscordYONE.py`

------
https://chatgpt.com/codex/tasks/task_e_686277052834832c8938b4c55ba4ca35