### PR TITLE
Read token/API key from env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,10 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
+# Bot credentials (not meant to be tracked)
+token.txt
+OPENAIKEY.txt
+
 # Marimo
 marimo/_static/
 marimo/_lsp/

--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -10,11 +10,22 @@ from typing import Any
 # ───────────────── TOKEN / KEY ─────────────────
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join(ROOT_DIR, "token.txt"), "r", encoding="utf-8") as f:
-    TOKEN = f.read().strip()
+# Prefer environment variables; fall back to local files for compatibility
+TOKEN = os.getenv("DISCORD_TOKEN")
+if not TOKEN:
+    try:
+        with open(os.path.join(ROOT_DIR, "token.txt"), "r", encoding="utf-8") as f:
+            TOKEN = f.read().strip()
+    except FileNotFoundError:
+        TOKEN = ""
 
-with open(os.path.join(ROOT_DIR, "OPENAIKEY.txt"), "r", encoding="utf-8") as f:
-    OPENAI_API_KEY = f.read().strip()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    try:
+        with open(os.path.join(ROOT_DIR, "OPENAIKEY.txt"), "r", encoding="utf-8") as f:
+            OPENAI_API_KEY = f.read().strip()
+    except FileNotFoundError:
+        OPENAI_API_KEY = ""
 
 openai_client = OpenAI(api_key=OPENAI_API_KEY)
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Discord の入力欄で `/` を入力し、コマンド名を選択します。
    ```bash
    pip install -r requirements.txt
    ```
-3. Discord の Bot トークンを `token.txt` に、OpenAI API キーを `OPENAIKEY.txt` に保存します。
+3. `DISCORD_TOKEN` と `OPENAI_API_KEY` 環境変数に、それぞれ Bot トークンと OpenAI API キーを設定します。
+   ファイルに平文で保存する代わりに環境変数を用いることで、認証情報をリポジトリへ誤って登録するのを防げます。
 4. 音楽再生には `ffmpeg` が必要です。システムにインストールしてから下記を実行してください。
    ```bash
    python DiscordYONE.py


### PR DESCRIPTION
## Summary
- ignore credential files in git
- read API key and token from environment variables
- document environment variable setup in README

## Testing
- `python -m py_compile DiscordYONE.py`


------
https://chatgpt.com/codex/tasks/task_e_6862825e9abc832ca509136744d38bea