### PR TITLE
Ensure up‑to‑date member status in /user

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -1112,6 +1112,12 @@ async def cmd_date(msg: discord.Message, arg: str):
 async def build_user_embed(target: discord.User | discord.Member,
                            member: discord.Member | None,
                            channel: discord.abc.Messageable) -> discord.Embed:
+    # Fetch the latest Member info for accurate presence
+    if member is not None:
+        try:
+            member = await member.guild.fetch_member(member.id)
+        except Exception:
+            pass
     embed = discord.Embed(title="ユーザー情報", colour=0x2ecc71)
     embed.set_thumbnail(url=target.display_avatar.url)
 
@@ -1193,12 +1199,10 @@ async def cmd_user(msg: discord.Message, arg: str = ""):
 
     member: discord.Member | None = None
     if msg.guild:
-        member = msg.guild.get_member(target.id)
-        if member is None:
-            try:
-                member = await msg.guild.fetch_member(target.id)
-            except discord.NotFound:
-                member = None
+        try:
+            member = await msg.guild.fetch_member(target.id)
+        except discord.NotFound:
+            member = None
 
     embed = await build_user_embed(target, member, msg.channel)
     await msg.channel.send(embed=embed)


### PR DESCRIPTION
## Summary
- fetch a fresh Member object when building user embeds
- call `guild.fetch_member` in `cmd_user`
- presence intents already enabled via `Intents.presences=True`

## Testing
- `python -m py_compile DiscordYONE.py`

------
https://chatgpt.com/codex/tasks/task_e_68628241dd0c832c8325436b648a1f66