### PR TITLE
Implement cleanup for TranscriptionSink

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -193,6 +193,19 @@ class TranscriptionSink(voice_recv.AudioSink):
                 logger.error(f"TTS error: {e}")
 
 
+    def cleanup(self) -> None:
+        for uid, (wf, path) in list(self.user_files.items()):
+            try:
+                wf.close()
+            except Exception:
+                logger.warning(f"Error closing audio file for {uid}", exc_info=True)
+            try:
+                os.remove(path)
+            except Exception:
+                logger.warning(f"Error removing audio file for {uid}", exc_info=True)
+        self.user_files.clear()
+
+
 @dataclass
 class Track:
     title: str


### PR DESCRIPTION
## Summary
- add a cleanup method to `TranscriptionSink` that closes and removes user temp files

## Testing
- `ruff check DiscordYONE.py | head -n 20`
- `black --check DiscordYONE.py` *(fails: would reformat)*
- `pyright DiscordYONE.py` *(fails: type errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628240f7a8832ca3a8f41c1faa1e83