### PR TITLE
Fix TranscriptionSink compatibility with discord-ext-voice-recv

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -141,8 +141,8 @@ class TranscriptionSink(voice_recv.AudioSink):
     def wants_opus(self) -> bool:
         return False  # receive PCM
 
-    def write(self, data: voice_recv.VoiceData):
-        member = data.member
+    def write(self, user: discord.User | discord.Member | None, data: voice_recv.VoiceData):
+        member = user or data.source
         if member is None or data.pcm is None:
             return
         uid = member.id


### PR DESCRIPTION
## Summary
- update `TranscriptionSink.write` to accept `(user, data)` as required by new
  `discord-ext-voice-recv` router API

## Testing
- `python -m py_compile DiscordYONE.py`

------
https://chatgpt.com/codex/tasks/task_e_68628996b54c832ca29639a50975c479