### PR TITLE
Fix transcription process for OpenAI return type

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -172,12 +172,12 @@ class TranscriptionSink(voice_recv.AudioSink):
         tts_path = None
         try:
             with open(path, "rb") as f:
-                text = openai_client.audio.transcriptions.create(
+                resp = openai_client.audio.transcriptions.create(
                     model="whisper-1",
                     file=f,
                     language="ja",
                 )
-            text = text.strip()
+            text = resp.text.strip()
 
             chan_id = transcript_channels.get(member.guild.id)
             if chan_id:


### PR DESCRIPTION
## Summary
- fix transcribed text extraction in `TranscriptionSink.process_file`

## Testing
- `python -m py_compile DiscordYONE.py`
- `python test_transcription.py` *(no output except `done`)*

------
https://chatgpt.com/codex/tasks/task_e_686292a97028832cbde9a2306fb3aaa9