### PR TITLE
Add environment example and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration
+# Copy this file to `.env` and fill in your own credentials.
+DISCORD_TOKEN=your-discord-token-here
+OPENAI_API_KEY=your-openai-api-key-here

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ Discord の入力欄で `/` を入力し、コマンド名を選択します。
    ```bash
    pip install -r requirements.txt
    ```
-3. `DISCORD_TOKEN` と `OPENAI_API_KEY` 環境変数に、それぞれ Bot トークンと OpenAI API キーを設定します。
-   ファイルに平文で保存する代わりに環境変数を用いることで、認証情報をリポジトリへ誤って登録するのを防げます。
+3. ルートにある `.env.example` を `.env` にコピーし、`DISCORD_TOKEN` と `OPENAI_API_KEY` を設定します。
+   `.env` は `.gitignore` で除外されているため、**絶対にコミットしないでください**。
+   必要に応じて `source .env` などで環境変数を読み込んでください。
 4. 音楽再生には `ffmpeg` が必要です。システムにインストールしてから下記を実行してください。
    ```bash
    python DiscordYONE.py


### PR DESCRIPTION
## Summary
- add `.env.example` template
- document how to create a `.env` file and warn not to commit it

## Testing
- `python -m py_compile DiscordYONE.py`

------
https://chatgpt.com/codex/tasks/task_e_68629c2695b4832c95c177fc28f5cfa1