### PR TITLE
Load .env automatically

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # Example environment configuration
 # Copy this file to `.env` and fill in your own credentials.
-DISCORD_TOKEN=MTMyNDIyNzUzNTY2NzU5MzMxNw.GIL-Qz.hfVBaeN1IKcCUQmvvdunJvpJ1e5-ns2El52U7E
-OPENAI_API_KEY=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
+DISCORD_TOKEN=your-discord-token-here
+OPENAI_API_KEY=your-openai-api-key-here

--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -3,12 +3,16 @@ from discord import app_commands
 from openai import OpenAI, AsyncOpenAI
 from urllib.parse import urlparse, parse_qs
 from logging.handlers import RotatingFileHandler
+from dotenv import load_dotenv
 
 from dataclasses import dataclass
 from typing import Any
 
 # ───────────────── TOKEN / KEY ─────────────────
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Load environment variables from .env if present
+load_dotenv(os.path.join(ROOT_DIR, ".env"))
 
 # Load credentials from environment variables
 TOKEN = os.getenv("DISCORD_TOKEN", "")

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Discord の入力欄で `/` を入力し、コマンド名を選択します。
    ```
 3. ルートにある `.env.example` を `.env` にコピーし、`DISCORD_TOKEN` と `OPENAI_API_KEY` を設定します。
    `.env` は `.gitignore` で除外されているため、**絶対にコミットしないでください**。
-   必要に応じて `source .env` などで環境変数を読み込んでください。
+   Bot は起動時に `.env` を自動で読み込むため、通常は `source .env` などを実行する必要はありません。
 4. 音楽再生には `ffmpeg` が必要です。システムにインストールしてから下記を実行してください。
    ```bash
    python DiscordYONE.py

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -34,6 +34,7 @@ pydantic==2.11.7
 pydantic_core==2.33.2
 Pygments==2.19.1
 PyNaCl==1.5.0
+python-dotenv==1.1.1
 pyright==1.1.402
 pytest==8.4.0
 ruff==0.11.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py==2.5.2
 openai==1.93.0
 yt-dlp==2025.6.25
 discord-ext-voice-recv==0.5.2a179
+python-dotenv==1.1.1


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- add `python-dotenv` dependency
- document that `.env` is loaded automatically
- restore placeholder credentials in `.env.example`

## Testing
- `python -m py_compile DiscordYONE.py`

------
https://chatgpt.com/codex/tasks/task_e_6862a269fbcc832cbc50c7fbcc392191