### PR TITLE
Fix incorrect error message in quote buttons

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -661,7 +661,7 @@ class QuoteView(discord.ui.View):
         except Exception:
             await inter.response.send_message(
                 "⚠️ この操作パネルは無効です。\n"
-                "`y!queue` で新しいパネルを表示してね！",
+                "`y!?` をもう一度返信してみてね！",
                 ephemeral=True,
             )
 
@@ -673,7 +673,7 @@ class QuoteView(discord.ui.View):
         except Exception:
             await inter.response.send_message(
                 "⚠️ この操作パネルは無効です。\n"
-                "`y!queue` で新しいパネルを表示してね！",
+                "`y!?` をもう一度返信してみてね！",
                 ephemeral=True,
             )
 


### PR DESCRIPTION
## Summary
- correct the error message text for QuoteView buttons so they mention `y!?`

## Testing
- `python -m py_compile DiscordYONE.py`


------
https://chatgpt.com/codex/tasks/task_e_68634d375040832c9c00718e345dcb4a