### PR TITLE
Improve barcode command error handling

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -1945,8 +1945,12 @@ async def cmd_barcode(msg: discord.Message, text: str) -> None:
 
     import barcode
     from barcode.writer import ImageWriter
-
-    code = barcode.get("code128", text, writer=ImageWriter())
+    from barcode.errors import IllegalCharacterError
+    try:
+        code = barcode.get("code128", text, writer=ImageWriter())
+    except IllegalCharacterError:
+        await msg.reply("Code128 では英数字など ASCII 文字のみ利用できます。", delete_after=5)
+        return
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
     path = tmp.name
     tmp.close()


### PR DESCRIPTION
## Summary
- handle `IllegalCharacterError` in barcode generator so ASCII-only errors are reported to user

## Testing
- `python -m py_compile DiscordYONE.py`


------
https://chatgpt.com/codex/tasks/task_e_6863990aeb24832ca118e40b4566fe84