### PR TITLE
Add OPENAI_API_KEY runtime check

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -2848,4 +2848,6 @@ async def on_message(msg: discord.Message):
 if __name__ == "__main__":
     if not TOKEN:
         raise RuntimeError("DISCORD_TOKEN is not set. Check your environment variables or .env file")
+    if not OPENAI_API_KEY:
+        raise RuntimeError("OPENAI_API_KEY is not set. Check your environment variables or .env file")
     client.run(TOKEN)


### PR DESCRIPTION
## Summary
- ensure OPENAI_API_KEY is checked when starting the bot

## Testing
- `python -m py_compile DiscordYONE.py`

------
https://chatgpt.com/codex/tasks/task_e_68639e49a248832ca8f2e0f12c10498b