### PR TITLE
Fix poker card emoji mapping

### DIFF
--- a/poker.py
+++ b/poker.py
@@ -11,13 +11,13 @@ from treys import Card, Deck, Evaluator
 
 
 # Basic text emoji for card suits
-SUITS = ["♣", "♦", "♥", "♠"]
+SUIT_MAP = {"s": "♠", "h": "♥", "d": "♦", "c": "♣"}
 RANKS = "23456789TJQKA"
 
 def card_to_emoji(card: int) -> str:
     rank = Card.get_rank_int(card)
-    suit = Card.get_suit_int(card)
-    return f"{RANKS[rank-2]}{SUITS[suit]}"
+    suit_char = Card.INT_SUIT_TO_CHAR_SUIT[Card.get_suit_int(card)]
+    return f"{RANKS[rank]}{SUIT_MAP[suit_char]}"
 
 
 def format_hand(cards: List[int]) -> str:


### PR DESCRIPTION
## Summary
- map treys suit integers to correct emoji symbols

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b3603d6c832c82857b3fedf35734