### PR TITLE
Fix message update failure handling in Poker game

### DIFF
--- a/poker.py
+++ b/poker.py
@@ -229,7 +229,10 @@ class PokerMatch:
         if self.message is None:
             self.message = await self.channel.send(embed=embed)
         else:
-            await self.message.edit(embed=embed)
+            try:
+                await self.message.edit(embed=embed)
+            except discord.HTTPException:
+                self.message = await self.channel.send(embed=embed)
 
 
 class PokerView(discord.ui.View):


### PR DESCRIPTION
## Summary
- handle `discord.HTTPException` when editing the poker status message
- post a new message on failure so gameplay continues

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863b583e024832ca4dd2b47b0c2e82b