### PR TITLE
Fix DM error when bot is poker opponent

### DIFF
--- a/poker.py
+++ b/poker.py
@@ -90,6 +90,8 @@ class PokerMatch:
 
     async def _send_hands(self):
         for p in self.players:
+            if p.user.id == self.bot_user.id:
+                continue
             try:
                 dm = await p.user.create_dm()
                 await dm.send(f"Your hand: {format_hand(p.hand)}")


### PR DESCRIPTION
## Summary
- avoid DMing the bot user during poker games

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c0f92cdc832c93b5b4ebf3e5441d