### PR TITLE
Fix purge command message type check

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -1608,7 +1608,11 @@ async def cmd_purge(msg: discord.Message, arg: str):
         if m.id == msg.id:
             return False
         if (
-            m.type == discord.MessageType.application_command
+            m.type
+            in (
+                discord.MessageType.chat_input_command,
+                discord.MessageType.context_menu_command,
+            )
             and m.interaction
             and m.interaction.id == msg.id
         ):


### PR DESCRIPTION
## Summary
- fix the `MessageType` constant for skipping interaction messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863c34898d0832c894309cd52ff1a5c