### PR TITLE
Fix bot action when player all-ins

### DIFF
--- a/poker.py
+++ b/poker.py
@@ -186,7 +186,7 @@ class PokerMatch:
         else:
             self._next_turn()
         await self._update_message()
-        if self._current_player_is_bot() and not self._any_player_allin():
+        if self._current_player_is_bot():
             await self._bot_action()
 
     async def _next_stage(self):


### PR DESCRIPTION
## Summary
- ensure poker bot still acts when an opponent is all-in

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864daa04540832cb469d8664d81ce54