### PR TITLE
Enhance news summary flow

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -77,3 +77,4 @@ typing_extensions==4.14.0
 urllib3==2.5.0
 yarl==1.20.1
 yt-dlp==2025.6.25
+beautifulsoup4==4.12.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ python-barcode[images]
 treys
 feedparser
 matplotlib
+beautifulsoup4


### PR DESCRIPTION
## Summary
- fetch full article text with BeautifulSoup and summarize that
- store hourly news summaries for a daily digest
- post seven news items every hour
- send a digest of the previous day's news at midnight
- add `beautifulsoup4` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e26b3e48832cb823784cdf37066f