### PR TITLE
Fix GPT replies to maintain reply chain

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -1447,7 +1447,7 @@ import asyncio
 
 async def cmd_gpt(msg: discord.Message, prompt: str):
     if not prompt:
-        await msg.channel.send("`y?` の後に質問を書いてね！"); return
+        await msg.reply("`y?` の後に質問を書いてね！"); return
     async with msg.channel.typing():
         try:
             # ストリーミングで応答を受信
@@ -1463,7 +1463,7 @@ async def cmd_gpt(msg: discord.Message, prompt: str):
                 stream=True,
             )
 
-            reply = await msg.channel.send("…")
+            reply = await msg.reply("…")
             text = ""
             buf = ""
             last_edit = time.monotonic()
@@ -1489,7 +1489,7 @@ async def cmd_gpt(msg: discord.Message, prompt: str):
             else:
                 await reply.edit(content=text)
         except Exception as e:
-            await msg.channel.send(f"エラー: {e}", delete_after=5)
+            await msg.reply(f"エラー: {e}", delete_after=5)
 
 # ──────────── 🎵  コマンド郡 ────────────
 


### PR DESCRIPTION
## Summary
- adjust `cmd_gpt` to respond using `msg.reply` instead of `channel.send`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fec00cdc832cb5773e6c03af153b