### PR TITLE
Fix OpenAI tool usage

### DIFF
--- a/DiscordYONE.py
+++ b/DiscordYONE.py
@@ -103,7 +103,10 @@ EEW_CHANNEL_ID = _load_eew_channel()
 LAST_EEW_ID = _load_last_eew()
 WEATHER_CHANNEL_ID = _load_weather_channel()
 
-openai_client = OpenAI(api_key=OPENAI_API_KEY)
+openai_client = OpenAI(
+    api_key=OPENAI_API_KEY,
+    default_headers={"OpenAI-Beta": "assistants=v2"},
+)
 
 # ───────────────── Voice Transcription / TTS ─────────────────
 
@@ -1459,7 +1462,10 @@ async def cmd_gpt(msg: discord.Message, messages: list[dict[str, str]]):
     async with msg.channel.typing():
         try:
             # ストリーミングで応答を受信
-            client = AsyncOpenAI(api_key=OPENAI_API_KEY)
+            client = AsyncOpenAI(
+                api_key=OPENAI_API_KEY,
+                default_headers={"OpenAI-Beta": "assistants=v2"},
+            )
             stream = await client.chat.completions.create(
                 model="gpt-4.1",
                 tools=[


### PR DESCRIPTION
## Summary
- add `OpenAI-Beta` header so the web search and code interpreter tools work

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686906ddf1e8832c83d60c1cb9072c23